### PR TITLE
feat: change the registry from Docker hub to GitHub Container Registry.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: ghcr.io/revsystem/postfix
           tags: |
@@ -35,8 +35,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
+      - name: Login to GHCR
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.API_GITHUB_TOKEN }}
 
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v2
         with:
-          images: revsystem/postfix
+          images:  ghcr.io/revsystem/postfix
           tags: |
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -15,9 +15,9 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v2
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images:  ghcr.io/revsystem/postfix
+          images: ghcr.io/revsystem/postfix
           tags: |
             type=semver,pattern={{major}}
             type=semver,pattern={{major}}.{{minor}}
@@ -35,12 +35,13 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
+          context: .
           push: true
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64
           tags: ${{ steps.docker_meta.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Or you can use the provided [docker-compose](https://github.com/revsystem/docker
 
     docker-compose build
 
-For more information on using multiple compose files [see here](https://docs.docker.com/compose/production/). You can also find a prebuilt docker image from [Docker Hub](https://registry.hub.docker.com/r/revsystem/postfix/), which can be pulled with this command:
+For more information on using multiple compose files [see here](https://docs.docker.com/compose/production/). You can also find a prebuilt docker image from [GitHub Container Registry](https://github.com/revsystem/docker-postfix/pkgs/container/postfix), which can be pulled with this command:
 
-    docker pull revsystem/postfix:latest
+    docker pull ghcr.io/revsystem/postfix:latest
 
 ### How to run it
 


### PR DESCRIPTION
## Description of the change
change the registry from Docker hub to GitHub Container Registry.

## Motivation and Context
When we use docker pull, we need to log-in to docker through `docker login` command.
If we push our container images to GitHub Container Registry, we can docker pull without log-in.


